### PR TITLE
画像のダウンロードを並列化

### DIFF
--- a/download.go
+++ b/download.go
@@ -38,9 +38,9 @@ func fetchStamp(urlString string) (*LineStamp, error) {
 	scanner := bufio.NewScanner(resp.Body)
 	for scanner.Scan() {
 		line := scanner.Text()
-		if strings.Contains(line, "mdCMN08Ttl") {
+		if strings.Contains(line, "mdCMN38Item01Ttl") {
 			start := strings.Index(line, ">")
-			end := strings.Index(line, "</h3>")
+			end := strings.Index(line, "</p>")
 			title = line[start+1 : end]
 		}
 

--- a/download.go
+++ b/download.go
@@ -2,11 +2,14 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"errors"
 	"html"
 	"image"
 	"net/http"
 	"strings"
+
+	"golang.org/x/sync/errgroup"
 )
 
 func fetchStamps(urls []string) ([]*LineStamp, error) {
@@ -55,20 +58,34 @@ func fetchStamp(urlString string) (*LineStamp, error) {
 		title:  html.UnescapeString(title),
 		images: []image.Image{},
 	}
-	for _, u := range urls {
-		i, err := download(u)
-		if err != nil {
-			return nil, err
-		}
 
-		s.images = append(s.images, i)
+	eg, ctx := errgroup.WithContext(context.TODO())
+	for _, u := range urls {
+		eg.Go(func() error {
+			i, err := download(ctx, u)
+			if err != nil {
+				return err
+			}
+			s.images = append(s.images, i)
+			return nil
+		})
 	}
 
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
 	return &s, nil
 }
 
-func download(urlString string) (image.Image, error) {
-	resp, err := http.Get(urlString)
+func download(ctx context.Context, urlString string) (image.Image, error) {
+	req, err := http.NewRequest(http.MethodGet, urlString, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req = req.WithContext(ctx)
+	client := http.DefaultClient
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- LINE StoreのHTMLタグの変更によりスタンプのタイトルが取得できなくなっていたのを修正
- 画像のダウンロード部分を並列化

close #2 
