### PR TITLE
data-previewからダウンロードURLを決定する

### DIFF
--- a/download.go
+++ b/download.go
@@ -41,6 +41,12 @@ func stampTypeURL(ldp *lineDataPreview) (*url.URL, error) {
 	}
 }
 
+// lineDataPreviews is a collection object for lineDataPreview
+type lineDataPreviews struct {
+	Title        string
+	DataPreviews []*lineDataPreview
+}
+
 func fetchStamps(urls []string) ([]*LineStamp, error) {
 	var stamps []*LineStamp
 	for _, u := range urls {

--- a/download.go
+++ b/download.go
@@ -12,6 +12,17 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+// lineDataPreview is a object relational mapping structure
+type lineDataPreview struct {
+	Type              string `json:"type"`
+	ID                string `json:"id"`
+	StaticURL         string `json:"staticUrl"`
+	FallbackStaticURL string `json:"fallbackStaticUrl"`
+	AnimationURL      string `json:"animationUrl"`
+	PopupURL          string `json:"popupUrl"`
+	SoundURL          string `json:"soundUrl"`
+}
+
 func fetchStamps(urls []string) ([]*LineStamp, error) {
 	var stamps []*LineStamp
 	for _, u := range urls {

--- a/download.go
+++ b/download.go
@@ -7,6 +7,7 @@ import (
 	"html"
 	"image"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"golang.org/x/sync/errgroup"
@@ -21,6 +22,23 @@ type lineDataPreview struct {
 	AnimationURL      string `json:"animationUrl"`
 	PopupURL          string `json:"popupUrl"`
 	SoundURL          string `json:"soundUrl"`
+}
+
+func stampTypeURL(ldp *lineDataPreview) (*url.URL, error) {
+	switch ldp.Type {
+	case "static":
+		return url.Parse(ldp.StaticURL)
+	case "animation":
+		return url.Parse(ldp.AnimationURL)
+	case "popup":
+		return url.Parse(ldp.PopupURL)
+	case "sound":
+		return url.Parse(ldp.SoundURL)
+	case "animation_sound":
+		return nil, errors.New("ボイス・サウンド付きスタンプには対応していません")
+	default:
+		return nil, errors.New("対応していません")
+	}
 }
 
 func fetchStamps(urls []string) ([]*LineStamp, error) {

--- a/download.go
+++ b/download.go
@@ -44,8 +44,8 @@ func stampTypeURL(ldp *lineDataPreview) (*url.URL, error) {
 
 // lineDataPreviews is a collection object for lineDataPreview
 type lineDataPreviews struct {
-	Title        string
-	DataPreviews []*lineDataPreview
+	title        string
+	dataPreviews []*lineDataPreview
 }
 
 // FetchStamps is a function that fetches Stamps from input url
@@ -111,8 +111,8 @@ func fetchStampData(urlString string) (*lineDataPreviews, error) {
 	}
 
 	return &lineDataPreviews{
-		Title:        html.UnescapeString(title),
-		DataPreviews: dataPreviews[1:],
+		title:        html.UnescapeString(title),
+		dataPreviews: dataPreviews[1:],
 	}, nil
 }
 
@@ -122,7 +122,7 @@ func downloadStamp(dps *lineDataPreviews) (*LineStamp, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	for _, dp := range dps.DataPreviews {
+	for _, dp := range dps.dataPreviews {
 		id := dp.ID
 		u, err := stampTypeURL(dp)
 		if err != nil {
@@ -149,7 +149,7 @@ func downloadStamp(dps *lineDataPreviews) (*LineStamp, error) {
 	}
 
 	return &LineStamp{
-		Title:    dps.Title,
+		Title:    dps.title,
 		Stickers: stickers,
 	}, nil
 }

--- a/lineStamp.go
+++ b/lineStamp.go
@@ -8,18 +8,26 @@ import (
 
 var lineStore = "https://store.line.me/stickershop"
 
-// LineStamp is a object
-type LineStamp struct {
-	title  string
-	images []image.Image
+// LineSticker is an object for a Line stamp image
+type LineSticker struct {
+	ID    string
+	Image image.Image
 }
 
-func (s *LineStamp) filledBackgroundImage(clr color.Color) []image.Image {
-	var imgs []image.Image
-	for _, img := range s.images {
-		imgs = append(imgs, fillBackground(img, color.RGBA{255, 255, 255, 255}))
-	}
-	return imgs
+// StoreName is the sticker name for saving
+func (s *LineSticker) StoreName() string {
+	return s.ID + ".png"
+}
+
+// FilledBackgroundImage is the sticker image for saving
+func (s *LineSticker) FilledBackgroundImage(clr color.Color) image.Image {
+	return fillBackground(s.Image, color.RGBA{255, 255, 255, 255})
+}
+
+// LineStamp is a collection object for LineSticker
+type LineStamp struct {
+	Title    string
+	Stickers []LineSticker
 }
 
 // IsLineStoreURL returns a boolean indicating whether the string is a LINE STORE stickershop url

--- a/main.go
+++ b/main.go
@@ -41,7 +41,7 @@ func main() {
 		os.Exit(2)
 	}
 
-	ss, err := fetchStamps(args)
+	ss, err := FetchStamps(args)
 	if err != nil {
 		fatalln(err)
 	}

--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ func main() {
 	}
 
 	for _, s := range ss {
-		err = storeStamp(s, absPath)
+		err = StoreStamp(s, absPath)
 		if err != nil {
 			fatalln(err)
 		}

--- a/store.go
+++ b/store.go
@@ -16,13 +16,14 @@ func storeStamp(s *LineStamp, dir string) error {
 		return errors.New(dir + " というディレクトリは存在しません。")
 	}
 
-	outDir := filepath.Join(dir, s.title)
+	outDir := filepath.Join(dir, s.Title)
 	info, err = os.Stat(outDir)
 	if err != nil && !os.IsExist(err) || !info.IsDir() {
 		_ = os.Mkdir(outDir, 0755)
 	}
 
-	for i, img := range s.filledBackgroundImage(color.RGBA{255, 255, 255, 255}) {
+	for i, sticker := range s.Stickers {
+		img := sticker.FilledBackgroundImage(color.RGBA{255, 255, 255, 255})
 		name := strconv.Itoa(i) + ".png"
 		absName := filepath.Join(outDir, name)
 		err := writeFile(img, absName)

--- a/store.go
+++ b/store.go
@@ -7,10 +7,10 @@ import (
 	"image/png"
 	"os"
 	"path/filepath"
-	"strconv"
 )
 
-func storeStamp(s *LineStamp, dir string) error {
+// StoreStamp is a function that saves an input stamp to input dir
+func StoreStamp(s *LineStamp, dir string) error {
 	info, err := os.Stat(dir)
 	if err != nil && !os.IsExist(err) || !info.IsDir() {
 		return errors.New(dir + " というディレクトリは存在しません。")
@@ -22,11 +22,9 @@ func storeStamp(s *LineStamp, dir string) error {
 		_ = os.Mkdir(outDir, 0755)
 	}
 
-	for i, sticker := range s.Stickers {
-		img := sticker.FilledBackgroundImage(color.RGBA{255, 255, 255, 255})
-		name := strconv.Itoa(i) + ".png"
-		absName := filepath.Join(outDir, name)
-		err := writeFile(img, absName)
+	for _, sticker := range s.Stickers {
+		absName := filepath.Join(outDir, sticker.StoreName())
+		err := writeFile(sticker.FilledBackgroundImage(color.RGBA{255, 255, 255, 255}), absName)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
for #10 

data-previewを取得すれば、どのカテゴリーのスタンプでもURLが取得できる。
対応できないカテゴリーの場合はstaticURLを使うようにすれば、とりあえずはどのスタンプでも取得できるようになるはず